### PR TITLE
Update RNReachabilityModule.java - Issue: isReachable always return false on android

### DIFF
--- a/android/src/main/java/com/younics/reachability/RNReachabilityModule.java
+++ b/android/src/main/java/com/younics/reachability/RNReachabilityModule.java
@@ -7,6 +7,9 @@ import com.facebook.react.bridge.ReactApplicationContext;
 import com.facebook.react.bridge.ReactContextBaseJavaModule;
 import com.facebook.react.bridge.ReactMethod;
 
+import java.net.Socket;
+import java.io.IOException;
+import java.net.InetSocketAddress;
 import java.net.InetAddress;
 
 public class RNReachabilityModule extends ReactContextBaseJavaModule {
@@ -25,10 +28,15 @@ public class RNReachabilityModule extends ReactContextBaseJavaModule {
 
   @ReactMethod
   public void isReachable(int timeout, final Promise promise) {
+    int timeOutMillis = 5000;
+    if(timeout>0) timeOutMillis = timeout;
     try {
-      promise.resolve(InetAddress.getByName("8.8.8.8").isReachable(timeout));
-    } catch (Exception e){
-      promise.reject(e);
-    }
+		try (Socket soc = new Socket()) {
+        	soc.connect(new InetSocketAddress(InetAddress.getByName("8.8.8.8"), 443), timeOutMillis);
+	    }
+    	promise.resolve(true);
+	} catch (IOException ex) {
+    	promise.resolve(false);
+  	}
   }
 }


### PR DESCRIPTION
 Check reachability with socket instead
    
    Issue: isReachable always return false on android
    
    https://stackoverflow.com/questions/9922543/why-does-inetaddress-isreachable-return-false-when-i-can-ping-the-ip-address